### PR TITLE
Optimize for TOC-reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,13 @@
 # Contributing
 
-Thank you so much for your interest in contributing!. All types of contributions are encouraged and valued. See below for different ways to help, and details about how this project handles them!
+## How do I... <a name="toc"></a>
 
-Please make sure to read the relevant section before making your contribution! It will make it a lot easier for us maintainers to make the most of it and smooth out the experience for all involved. 💚
-
-The [Project Team](#join-the-project-team) looks forward to your contributions.~
-
-## How do I...
-
-* Ask or Say Something 🤔🐛😱
+* [Use This Guide](#introduction)?
+* Ask or Say Something? 🤔🐛😱
   * [Request Support](#request-support)
   * [Report an Error or Bug](#report-an-error-or-bug)
   * [Request a Feature](#request-a-feature)
-* Make Something 🤓👩🏽‍💻📜🍳
+* Make Something? 🤓👩🏽‍💻📜🍳
   * [Project Setup](#project-setup)
   * [Contribute Documentation](#contribute-documentation)
   * [Contribute Code](#contribute-code)
@@ -24,7 +19,15 @@ The [Project Team](#join-the-project-team) looks forward to your contributions.~
   * [Merge Pull Requests](#merge-pull-requests)
   * [Tag a Release](#tag-a-release)
   * [Join the Project Team](#join-the-project-team)
-* [Add a Guide Like This One To My Project](#attribution) 🤖😻👻
+* Add a Guide Like This One [To My Project](#attribution)? 🤖😻👻
+
+## Introduction
+
+Thank you so much for your interest in contributing!. All types of contributions are encouraged and valued. See the [table of contents](#toc) for different ways to help and details about how this project handles them!📝
+
+Please make sure to read the relevant section before making your contribution! It will make it a lot easier for us maintainers to make the most of it and smooth out the experience for all involved. 💚
+
+The [Project Team](#join-the-project-team) looks forward to your contributions. 🙌🏾✨
 
 ## Request Support
 


### PR DESCRIPTION
I noticed when looking at the contrib page that, with all the other random stuff github plops on the page, the actual table of contents ("How do I...") ended up buried to be under the fold.

I believe this is the most important part of the whole document, and the thing contributors actually care about looking at every time they open that document: it's the one section basically everyone will need to interact with.

So let's put it front and center, and super obvious the moment someone opens that page!